### PR TITLE
add a 9p server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/usbarmory/tamago-example
 go 1.20
 
 require (
+	github.com/Harvey-OS/ninep v0.0.0-20200724082702-d30a6d4f9789
 	github.com/arl/statsviz v0.5.2
 	github.com/btcsuite/btcd v0.23.4
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
@@ -16,6 +17,7 @@ require (
 	github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f
 	golang.org/x/crypto v0.9.0
 	golang.org/x/term v0.8.0
+	gvisor.dev/gvisor v0.0.0-20230118154312-8c6072b1c5c4
 )
 
 require (
@@ -33,5 +35,4 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.3.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gvisor.dev/gvisor v0.0.0-20230118154312-8c6072b1c5c4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Harvey-OS/ninep v0.0.0-20200724082702-d30a6d4f9789 h1:CTx4Ie/zMSBhZ+pjiklxmqF+HxDlXMXRDiUCCo6J0RY=
+github.com/Harvey-OS/ninep v0.0.0-20200724082702-d30a6d4f9789/go.mod h1:YmLTajv/R+cjEsJ8/vfGOckeEBbz06tgHlYBSpbe+eo=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/arl/statsviz v0.5.2 h1:0+F96LduGQx7HZlMTUL9PNHv7lixwWCdxJzWC+SGSkI=
 github.com/arl/statsviz v0.5.2/go.mod h1:UomKe3l2yafXH6/LnOt8xGbiU3CEl70J1LJSW1fZO/E=
@@ -86,16 +88,6 @@ github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7 h1:pJnqq1l2IkRD
 github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7/go.mod h1:oa7S6vwmh5KtGcZDluDIZ6P2xjI/hzVTB2SNohFYd58=
 github.com/usbarmory/imx-usbnet v0.0.0-20230503192114-c54f43365f06 h1:KXlR66d9JUo+js+usAR3UhWq2PfbMI5eP4CRXJedZH4=
 github.com/usbarmory/imx-usbnet v0.0.0-20230503192114-c54f43365f06/go.mod h1:neTfbY/fYRa0xTyXDr6BHfDuONwhHMRkX9yFuLlcUMo=
-github.com/usbarmory/tamago v0.0.0-20230515080748-d77bf7bb2931 h1:4wLz5ZTcy7VCcy2cL2C3RRSNkQDLRH/vqwtt0ufXtFA=
-github.com/usbarmory/tamago v0.0.0-20230515080748-d77bf7bb2931/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230515203810-9cd3f5151e90 h1:m2l1/C/WcS6AeRhiUHlFmPqYAQi8MBBeeDbYAU9pZZg=
-github.com/usbarmory/tamago v0.0.0-20230515203810-9cd3f5151e90/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230519092447-a9486f3b1e29 h1:Xt1frBHWdwpER4Ug3nxroGQvo1WpvtkZ6RJV2eLwU+o=
-github.com/usbarmory/tamago v0.0.0-20230519092447-a9486f3b1e29/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230522092914-75327eb1436c h1:EPuLcOzbfGNFXn/9X3DC5RnXIYWCxut80sfJQjUx7mk=
-github.com/usbarmory/tamago v0.0.0-20230522092914-75327eb1436c/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230525101905-62770e5868a6 h1:7BkwZRyCUamBFBt82P6rRE7/gx25epXI/vH/CJmQjE8=
-github.com/usbarmory/tamago v0.0.0-20230525101905-62770e5868a6/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f h1:2nCLV3Jp6rFZC6fk34ClkqBTF1IpWBm5dI+bPHxBQkE=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=

--- a/network/9p_server.go
+++ b/network/9p_server.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 The Ninep Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * The names of Ninep's contributors may not be used to endorse 
+// or promote products derived from this software without specific prior 
+// written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// UFS is a userspace server which exports a filesystem over 9p2000.
+//
+// By default, it will export / over a TCP on port 5640 under the username
+// of "harvey".
+package network
+
+import (
+	"log"
+	"net"
+
+	ufs "github.com/Harvey-OS/ninep/filesystem"
+	"github.com/Harvey-OS/ninep/protocol"
+	"gvisor.dev/gvisor/pkg/tcpip"
+)
+
+func start9pServer(l net.Listener, addr tcpip.Address, port uint16, nic tcpip.NICID) {
+	// Maybe it did not start. Life is like that sometimes.
+	if l == nil {
+		return
+	}
+
+	ufslistener, err := ufs.NewUFS(func(l *protocol.Listener) error {
+		//l.Trace = log.Printf
+		return nil
+	})
+	if err != nil {
+		log.Printf("ufslistener: %v", err)
+		return
+	}
+
+	if err := ufslistener.Serve(l); err != nil {
+		log.Print(err)
+	}
+	log.Printf("9p server exits ...")
+}

--- a/network/imx-usbnet.go
+++ b/network/imx-usbnet.go
@@ -66,6 +66,20 @@ func StartUSB(console consoleHandler, journalFile *os.File) (port *usb.USB) {
 	go startWebServer(listenerHTTP, IP, 80, false)
 	go startWebServer(listenerHTTPS, IP, 443, true)
 
+	// 9P is optional. If it can not be started, that's ok.
+	listener9P, err := iface.ListenerTCP4(564)
+
+	if err != nil {
+		log.Printf("could not initialize 9P listener, %v", err)
+	}
+
+	if listener9P != nil {
+		// 9p server (see 9p_server.go)
+		go func() {
+			start9pServer(listener9P, IP, 564, 1)
+		}()
+	}
+
 	journal = journalFile
 
 	cmd.DialTCP4 = iface.DialTCP4


### PR DESCRIPTION
Now, on startup, you can do this:
mount -t 9p -o trans=tcp,noextend 10.0.0.1   /armory
and then

ls /armory
ls /armory/dev
/armory/tamago-example.log

In follow-on commits, where devices are also visible, we can do this sort of thing:

see how things are set:
cat /armory/dev/blue
{"color": "blue","state": "on", "lasterror": <nil>}

Control them:
echo off | sudo dd of=/armory/dev/blue conv=notrunc

(the notrunc is sadly necessary)

If you have a graphics device on a board you can draw to it from the linux host.

You can develop a driver that runs on the host, and, when it works, compile it into the example with no changes.