### PR TITLE
add controllable device files for white and blue led

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/cloudflare/circl v1.3.3
+	github.com/dustinxie/ecc v0.0.0-20210511000915-959544187564
 	github.com/miekg/dns v1.1.54
 	github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e
 	github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7
@@ -17,14 +18,12 @@ require (
 	github.com/usbarmory/tamago v0.0.0-20230606125032-579ffa4bff5c
 	golang.org/x/crypto v0.9.0
 	golang.org/x/term v0.8.0
-	gvisor.dev/gvisor v0.0.0-20230118154312-8c6072b1c5c4
 )
 
 require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
-	github.com/dustinxie/ecc v0.0.0-20210511000915-959544187564 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
@@ -36,4 +35,5 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.3.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gvisor.dev/gvisor v0.0.0-20230118154312-8c6072b1c5c4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -90,12 +90,6 @@ github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7 h1:pJnqq1l2IkRD
 github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7/go.mod h1:oa7S6vwmh5KtGcZDluDIZ6P2xjI/hzVTB2SNohFYd58=
 github.com/usbarmory/imx-usbnet v0.0.0-20230503192114-c54f43365f06 h1:KXlR66d9JUo+js+usAR3UhWq2PfbMI5eP4CRXJedZH4=
 github.com/usbarmory/imx-usbnet v0.0.0-20230503192114-c54f43365f06/go.mod h1:neTfbY/fYRa0xTyXDr6BHfDuONwhHMRkX9yFuLlcUMo=
-github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f h1:2nCLV3Jp6rFZC6fk34ClkqBTF1IpWBm5dI+bPHxBQkE=
-github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230604213624-012a5f8a93c5 h1:v+9MtVx3YfRiq8NdkJIlEQvbOu/ZyoFc89iAQcF2L5o=
-github.com/usbarmory/tamago v0.0.0-20230604213624-012a5f8a93c5/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
-github.com/usbarmory/tamago v0.0.0-20230606092234-a1daf4483647 h1:5fo7DvWXRN0aaLjfDiH0un+6rmxiMxrGZ4eFRWypbTM=
-github.com/usbarmory/tamago v0.0.0-20230606092234-a1daf4483647/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 github.com/usbarmory/tamago v0.0.0-20230606125032-579ffa4bff5c h1:51c8YQ94RCoUUyC2blk3aQgnyNUJC2/LYvkqbZ9PQTY=
 github.com/usbarmory/tamago v0.0.0-20230606125032-579ffa4bff5c/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=

--- a/reg32_tamago.go
+++ b/reg32_tamago.go
@@ -1,0 +1,278 @@
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) WithSecure Corporation
+// https://foundry.withsecure.com
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package reg provides primitives for retrieving and modifying hardware
+// registers.
+//
+// This package is only meant to be used with `GOOS=tamago` as supported by the
+// TamaGo framework for bare metal Go on ARM/RISC-V SoCs, see
+// https://github.com/usbarmory/tamago.
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/usbarmory/tamago/board/usbarmory/mk2"
+)
+
+func Get(addr uint32, pos int, mask int) uint32 {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+	r := atomic.LoadUint32(reg)
+
+	return uint32((int(r) >> pos) & mask)
+}
+
+func Set(addr uint32, pos int) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r |= (1 << pos)
+
+	atomic.StoreUint32(reg, r)
+}
+
+func Clear(addr uint32, pos int) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r &= ^(1 << pos)
+
+	atomic.StoreUint32(reg, r)
+}
+
+func SetTo(addr uint32, pos int, val bool) {
+	if val {
+		Set(addr, pos)
+	} else {
+		Clear(addr, pos)
+	}
+}
+
+func SetN(addr uint32, pos int, mask int, val uint32) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r = (r & (^(uint32(mask) << pos))) | (val << pos)
+
+	atomic.StoreUint32(reg, r)
+}
+
+func ClearN(addr uint32, pos int, mask int) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r &= ^(uint32(mask) << pos)
+
+	atomic.StoreUint32(reg, r)
+}
+
+// defined in reg32_*.s
+// func Move(dst uint32, src uint32)
+
+func Read(addr uint32) uint32 {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+	return atomic.LoadUint32(reg)
+}
+
+func Write(addr uint32, val uint32) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+	atomic.StoreUint32(reg, val)
+}
+
+func WriteBack(addr uint32) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r |= r
+
+	atomic.StoreUint32(reg, r)
+}
+
+func Or(addr uint32, val uint32) {
+	reg := (*uint32)(unsafe.Pointer(uintptr(addr)))
+
+	r := atomic.LoadUint32(reg)
+	r |= val
+
+	atomic.StoreUint32(reg, r)
+}
+
+// Wait waits for a specific register bit to match a value. This function
+// cannot be used before runtime initialization with `GOOS=tamago`.
+func Wait(addr uint32, pos int, mask int, val uint32) {
+	for Get(addr, pos, mask) != val {
+		// tamago is single-threaded, give other goroutines a chance
+		runtime.Gosched()
+	}
+}
+
+// WaitFor waits, until a timeout expires, for a specific register bit to match
+// a value. The return boolean indicates whether the wait condition was checked
+// (true) or if it timed out (false). This function cannot be used before
+// runtime initialization.
+func WaitFor(timeout time.Duration, addr uint32, pos int, mask int, val uint32) bool {
+	start := time.Now()
+
+	for Get(addr, pos, mask) != val {
+		// tamago is single-threaded, give other goroutines a chance
+		runtime.Gosched()
+
+		if time.Since(start) >= timeout {
+			return false
+		}
+	}
+
+	return true
+}
+
+// WaitSignal waits, until a channel is closed, for a specific register bit to
+// match a value. The return boolean indicates whether the wait condition was
+// checked (true) or cancelled (false). This function cannot be used before
+// runtime initialization.
+func WaitSignal(done chan bool, addr uint32, pos int, mask int, val uint32) bool {
+	for Get(addr, pos, mask) != val {
+		// tamago is single-threaded, give other goroutines a chance
+		runtime.Gosched()
+
+		select {
+		case <-done:
+			return false
+		default:
+		}
+	}
+
+	return true
+}
+
+// reg32File represents a single, 32-bit-aligned, 32-bit-sized, register.
+type reg32File struct {
+	offset uint32
+}
+
+func init() {
+	log.Printf("=======> t9 device reg32")
+	err := syscall.MkDev("/dev/reg32", 0666, openReg32)
+	log.Printf("err %v", err)
+}
+
+func openReg32() (syscall.DevFile, error) {
+	return reg32File{}, nil
+}
+
+func (f reg32File) close() error {
+	return nil
+}
+
+var ErrNotAligned = errors.New("Not aligned")
+
+func check(size int, offset int64) error {
+	// The offset must be aligned x4
+	if (offset & 3) != 0 {
+		return fmt.Errorf("offset %#x: %w", ErrNotAligned)
+	}
+	// The size must be aligned x4
+	if (size & 3) != 0 {
+		return fmt.Errorf("size %#x: %w", ErrNotAligned)
+	}
+	return nil
+}
+
+func (f reg32File) Pread(b []byte, offset int64) (int, error) {
+	if err := check(len(b), offset); err != nil {
+		return -1, err
+	}
+	var longs = make([]uint32, len(b)/4)
+	// read them from the registers ...
+	binary.Write(bytes.NewBuffer(b), binary.LittleEndian, longs)
+
+	return len(b), nil
+}
+
+func (f reg32File) Pwrite(b []byte, offset int64) (int, error) {
+	if err := check(len(b), offset); err != nil {
+		return -1, err
+	}
+	var longs = make([]uint32, len(b)/4)
+	binary.Read(bytes.NewBuffer(b), binary.LittleEndian, longs)
+	return len(b), nil
+}
+
+type ledFile struct {
+	f         reg32File
+	color     string
+	onoff     string
+	lasterror error
+}
+
+var leds = []*ledFile{
+	&ledFile{color: "white", onoff: "on", f: reg32File{offset: 0}},
+	&ledFile{color: "blue", onoff: "on", f: reg32File{offset: 0}},
+}
+
+func init() {
+	syscall.MkDev("/dev/white", 0666, openwhite)
+	syscall.MkDev("/dev/blue", 0666, openblue)
+}
+
+func openwhite() (syscall.DevFile, error) {
+	return leds[0], nil
+}
+
+func openblue() (syscall.DevFile, error) {
+	return leds[1], nil
+}
+
+func (f ledFile) Close() error {
+	return nil
+}
+
+func (f ledFile) Pread(b []byte, offset int64) (int, error) {
+	n, err := bytes.NewReader([]byte(fmt.Sprintf(`{"color": %q,"state": %q, "lasterror": %v}`, f.color, f.onoff, f.lasterror))).ReadAt(b, offset)
+	if err == io.EOF && n > 0 {
+		err = nil
+	}
+	return n, err
+}
+
+func (f ledFile) Pwrite(b []byte, offset int64) (int, error) {
+	f.lasterror = fmt.Errorf("%v: %q", f, string(b))
+	cmd := strings.Fields(string(b))
+	if len(cmd) != 1 {
+		f.lasterror = fmt.Errorf("%q:%q usage: on|off", f.color, string(b))
+		return -1, fmt.Errorf("usage: blue|white on|off")
+	}
+	var onoff bool
+	switch cmd[0] {
+	case "on":
+		onoff = true
+	case "off":
+	default:
+		f.lasterror = fmt.Errorf("%q:%q usage: on|off", f.color, string(b))
+		log.Printf("%q:%q usage: on|off", f.color, string(b))
+		return -1, fmt.Errorf("%q:%q usage: on|off", f.color, string(b))
+	}
+
+	err := mk2.LED(f.color, onoff)
+
+	if err != nil {
+		log.Printf("%q:%q mk2.LED: %v", f.color, string(b), err)
+		f.lasterror = fmt.Errorf("%q:%q mk2.LED: %v", f.color, string(b), err)
+	}
+	return len(b), err
+}


### PR DESCRIPTION
With this change, assuming you have mounted the armory over 9p on /armory, you can do this
echo -n off | sudo dd of=/armory/dev/blue conv=notrunc echo -n on | sudo dd of=/armory/dev/blue conv=notrunc

i.e. control these devices programatically from the host.

This opens all kinds of possibilities. You might have a display of some sort, and can easily control it from the host via file operations.

More importantly, you can write a Go driver for some device, which uses only Go io and os package operations,
and debug this device, from the host.

Once your code is right, build it into tamago and have it run internally on the stick.

Your develop and debug environment, on the host, is the same environment, unchanged, on the device.
Signed-off-by: Ronald G Minnich <rminnich@gmail.com>