### PR TITLE
remove spaces from build string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@
 
 BUILD_USER ?= $(shell whoami)
 BUILD_HOST ?= $(shell hostname)
-BUILD_DATE ?= $(shell /bin/date -u "+%Y-%m-%d %H:%M:%S")
-BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
+BUILD_DATE ?= $(shell /bin/date -u "+%Y-%m-%d:%H:%M:%S")
+BUILD = ${BUILD_USER}@${BUILD_HOST}@${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 
 SHELL = /bin/bash


### PR DESCRIPTION
The embedded spaces in the build string make it very difficult to use u-root, as the shells tend to
lose the quoting at some point. It's difficult to do triple-level quoting across every version of Make.