### PR TITLE
TARGET=microvm: SMP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ TEXT_START := 0x80010000 # ramStart (defined in mem.go under relevant tamago/soc
 TAGS := $(TARGET)
 
 ifeq ($(TARGET),microvm)
+SMP ?= $(shell nproc)
 TEXT_START := 0x10010000 # ramStart (defined in mem.go under tamago/amd64 package) + 0x10000
 GOENV := GOOS=tamago GOARCH=amd64
 QEMU ?= qemu-system-x86_64 -machine microvm,x-option-roms=on,pit=off,pic=off,rtc=on \
-        -smp 4 \
+        -smp $(SMP) \
         -global virtio-mmio.force-legacy=false \
         -enable-kvm -cpu host,invtsc=on,kvmclock=on -no-reboot \
         -m 4G -nographic -monitor none -serial stdio \
         -device virtio-net-device,netdev=net0 -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
-        # -cpu IvyBridge-v2,invtsc=on,kvmclock=on -no-reboot -d cpu
 endif
 
 ifeq ($(TARGET),$(filter $(TARGET), firecracker cloud_hypervisor))

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,12 @@ ifeq ($(TARGET),microvm)
 TEXT_START := 0x10010000 # ramStart (defined in mem.go under tamago/amd64 package) + 0x10000
 GOENV := GOOS=tamago GOARCH=amd64
 QEMU ?= qemu-system-x86_64 -machine microvm,x-option-roms=on,pit=off,pic=off,rtc=on \
+        -smp 2 \
         -global virtio-mmio.force-legacy=false \
         -enable-kvm -cpu host,invtsc=on,kvmclock=on -no-reboot \
         -m 4G -nographic -monitor none -serial stdio \
         -device virtio-net-device,netdev=net0 -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
+        # -cpu IvyBridge-v2,invtsc=on,kvmclock=on -no-reboot -d cpu
 endif
 
 ifeq ($(TARGET),$(filter $(TARGET), firecracker cloud_hypervisor))

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(TARGET),microvm)
 TEXT_START := 0x10010000 # ramStart (defined in mem.go under tamago/amd64 package) + 0x10000
 GOENV := GOOS=tamago GOARCH=amd64
 QEMU ?= qemu-system-x86_64 -machine microvm,x-option-roms=on,pit=off,pic=off,rtc=on \
-        -smp 2 \
+        -smp 4 \
         -global virtio-mmio.force-legacy=false \
         -enable-kvm -cpu host,invtsc=on,kvmclock=on -no-reboot \
         -m 4G -nographic -monitor none -serial stdio \

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ QEMU
 ----
 
 ```
-make qemu TARGET=microvm
+make qemu TARGET=microvm SMP=4
 ```
 
 Firecracker
@@ -181,7 +181,7 @@ Example shown via [firectl](https://github.com/firecracker-microvm/firectl):
 
 ```
 make example TARGET=firecracker
-firectl --kernel example --root-drive /dev/null --tap-device tap0/06:00:AC:10:00:01 -c 1 -m 4096
+firectl --kernel example --root-drive /dev/null --tap-device tap0/06:00:AC:10:00:01 -c 4 -m 4096
 ```
 
 Building and executing on ARM targets

--- a/cmd/amd64.go
+++ b/cmd/amd64.go
@@ -109,6 +109,10 @@ func smpCmd(console *shell.Interface, arg []string) (string, error) {
 	ncpu := runtime.NumCPU()
 	wg.Add(n)
 
+	if runtime.ProcID == nil || runtime.Task == nil {
+		return "", errors.New("no SMP detected")
+	}
+
 	fmt.Fprintf(console.Output,"%d cores detected, launching %d goroutines from CPU%2d\n", ncpu, n, runtime.ProcID())
 
 	for i := 0; i < n; i++ {

--- a/cmd/amd64.go
+++ b/cmd/amd64.go
@@ -15,6 +15,8 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/usbarmory/tamago-example/shell"
 	"github.com/usbarmory/tamago/amd64"
@@ -31,6 +33,16 @@ func init() {
 		Syntax:  "<leaf> <subleaf>",
 		Help:    "display CPU capabilities",
 		Fn:      cpuidCmd,
+	})
+
+	shell.Add(shell.Cmd{
+		Name:    "smp",
+		Args:    1,
+		Pattern: regexp.MustCompile(`^smp (\d+)$`),
+		Syntax:  "<n>",
+
+		Help:    "launch SMP test",
+		Fn:      smpCmd,
 	})
 }
 
@@ -79,6 +91,53 @@ func cpuidCmd(_ *shell.Interface, arg []string) (string, error) {
 
 	fmt.Fprintf(&res, "EAX      EBX      ECX      EDX\n")
 	fmt.Fprintf(&res, "%08x %08x %08x %08x\n", eax, ebx, ecx, edx)
+
+	return res.String(), nil
+}
+
+func smpCmd(console *shell.Interface, arg []string) (string, error) {
+	var res bytes.Buffer
+	var wg sync.WaitGroup
+	var cc sync.Map
+
+	n, err := strconv.Atoi(arg[0])
+
+	if err != nil {
+		return "", fmt.Errorf("invalid goroutine count: %v", err)
+	}
+
+	ncpu := runtime.NumCPU()
+	wg.Add(n)
+
+	fmt.Fprintf(console.Output,"%d cores detected, launching %d goroutines from CPU%2d\n", ncpu, n, runtime.ProcID())
+
+	for i := 0; i < n; i++ {
+		go func() {
+			cpu := runtime.ProcID()
+
+			for {
+				if actual, loaded := cc.LoadOrStore(cpu, 1); loaded {
+					if cc.CompareAndSwap(cpu, actual.(int), actual.(int)+1) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	var total int
+
+	cc.Range(func(cpu any, count any) bool {
+		total += count.(int)
+		fmt.Fprintf(&res, "CPU%2d %3d:%s\n", cpu.(uint64), count.(int), strings.Repeat("░", count.(int)))
+		return true
+	})
+
+	fmt.Fprintf(&res, "Total %3d\n", total)
 
 	return res.String(), nil
 }

--- a/cmd/amd64.go
+++ b/cmd/amd64.go
@@ -44,7 +44,7 @@ func infoCmd(_ *shell.Interface, _ []string) (string, error) {
 	ramStart, ramEnd := runtime.MemRegion()
 	name, freq := Target()
 
-	fmt.Fprintf(&res, "Runtime ......: %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&res, "Runtime ......: %s %s/%s GOMAXPROCS=%d\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, runtime.GOMAXPROCS(-1))
 	fmt.Fprintf(&res, "RAM ..........: %#08x-%#08x (%d MiB)\n", ramStart, ramEnd, (ramEnd-ramStart)/(1024*1024))
 	fmt.Fprintf(&res, "Board ........: %s\n", boardName)
 	fmt.Fprintf(&res, "CPU ..........: %s\n", name)

--- a/cmd/mem.go
+++ b/cmd/mem.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strconv"
-	"sync"
 
 	"github.com/usbarmory/tamago-example/shell"
 	"github.com/usbarmory/tamago/dma"
@@ -115,7 +114,6 @@ func memWriteCmd(_ *shell.Interface, arg []string) (res string, err error) {
 
 func memTest() {
 	var memstats runtime.MemStats
-	var wg sync.WaitGroup
 
 	chunks := rand.Intn(chunksMax) + 1
 	chunkSize := fillSize / chunks
@@ -131,23 +129,17 @@ func memTest() {
 	debug.SetMemoryLimit(int64(math.Round(memoryLimit)))
 
 	msg("memory allocation (%d runs)", runs)
-	wg.Add(runs)
 
 	for run := 1; run <= runs; run++ {
-		go func() {
-			msg("allocating %d * %d MiB chunks (%d/%d)", chunks, chunkSize/(1024*1024), run, runs)
+		log.Printf("allocating %d * %d MiB chunks (%d/%d)", chunks, chunkSize/(1024*1024), run, runs)
 
-			buf := make([][]byte, chunks)
+		buf := make([][]byte, chunks)
 
-			for i := 0; i <= chunks-1; i++ {
-				buf[i] = make([]byte, chunkSize)
-			}
-
-			wg.Done()
-		}()
+		for i := 0; i <= chunks-1; i++ {
+			buf[i] = make([]byte, chunkSize)
+		}
 	}
 
-	wg.Wait()
 	runtime.GC()
 
 	runtime.ReadMemStats(&memstats)

--- a/cmd/mem.go
+++ b/cmd/mem.go
@@ -135,7 +135,7 @@ func memTest() {
 
 	for run := 1; run <= runs; run++ {
 		go func() {
-			log.Printf("allocating %d * %d MiB chunks (%d/%d)", chunks, chunkSize/(1024*1024), run, runs)
+			msg("allocating %d * %d MiB chunks (%d/%d)", chunks, chunkSize/(1024*1024), run, runs)
 
 			buf := make([][]byte, chunks)
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -8,13 +8,12 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/usbarmory/tamago-example/shell"
-
-	"github.com/usbarmory/tamago/board/qemu/microvm"
 )
 
 const (
@@ -41,7 +40,11 @@ func init() {
 
 func msg(format string, args ...interface{}) {
 	s := strings.Repeat(separator, 2) + " "
-	s += fmt.Sprintf(" CPU %d • ", microvm.AMD64.LAPIC.ID())
+
+	if runtime.ProcID != nil {
+		s += fmt.Sprintf(" CPU %d • ", runtime.ProcID())
+	}
+
 	s += fmt.Sprintf(format, args...)
 	s += " " + strings.Repeat(separator, separatorSize-len(s))
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -8,7 +8,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -40,11 +39,6 @@ func init() {
 
 func msg(format string, args ...interface{}) {
 	s := strings.Repeat(separator, 2) + " "
-
-	if runtime.ProcID != nil {
-		s += fmt.Sprintf(" CPU %d • ", runtime.ProcID())
-	}
-
 	s += fmt.Sprintf(format, args...)
 	s += " " + strings.Repeat(separator, separatorSize-len(s))
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/usbarmory/tamago-example/shell"
+
+	"github.com/usbarmory/tamago/board/qemu/microvm"
 )
 
 const (
@@ -39,6 +41,7 @@ func init() {
 
 func msg(format string, args ...interface{}) {
 	s := strings.Repeat(separator, 2) + " "
+	s += fmt.Sprintf(" CPU %d • ", microvm.AMD64.LAPIC.ID())
 	s += fmt.Sprintf(format, args...)
 	s += " " + strings.Repeat(separator, separatorSize-len(s))
 
@@ -90,11 +93,11 @@ func testCmd(_ *shell.Interface, _ []string) (_ string, _ error) {
 	msg("launched %d test goroutines", gr)
 
 	wait()
-
 	msg("completed all test goroutines (%s)", time.Since(start))
 
 	memTest()
 	storageTest()
+	msg("completed all tests (%s)", time.Since(start))
 
 	return
 }

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -42,7 +42,9 @@ func wakeTest() (tag string, res string) {
 
 	go func() {
 		time.Sleep(sleep)
-		runtime.Wake(uint(gp))
+		if !runtime.Wake(uint(gp)) {
+			panic("WakeG failed")
+		}
 	}()
 
 	time.Sleep(math.MaxInt64)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/usbarmory/tamago-example
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/Harvey-OS/ninep v0.0.0-20200724082702-d30a6d4f9789

--- a/go.mod
+++ b/go.mod
@@ -110,3 +110,5 @@ require (
 	nhooyr.io/websocket v1.8.17 // indirect
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1 // indirect
 )
+
+replace github.com/usbarmory/tamago => /mnt/git/public/tamago

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,6 @@ github.com/usbarmory/imx-enet v0.0.0-20250123113228-2e1bd913d818 h1:rT7AuUw3hI5+
 github.com/usbarmory/imx-enet v0.0.0-20250123113228-2e1bd913d818/go.mod h1:xv0Cs172SG66RZYFUX7XuZCuvHpiyE9Jgbz08Pwobqk=
 github.com/usbarmory/imx-usbnet v0.0.0-20250123113617-d39929cd7171 h1:0xXzXU689aEIa/UQ1wByXPbk+PogCKMMFoW8rFodQlI=
 github.com/usbarmory/imx-usbnet v0.0.0-20250123113617-d39929cd7171/go.mod h1:zvzUu4SfzoCEDVnxzga81SoK3ezsW8gjxck2v1Ry1zw=
-github.com/usbarmory/tamago v0.0.0-20250606075221-ca4bbc34635a h1:yElIHSNp42grSUl72dg+orAbbk7niHHdUvg+3nHlSZQ=
-github.com/usbarmory/tamago v0.0.0-20250606075221-ca4bbc34635a/go.mod h1:0Bc0GnC88LvCAoCRUcd3DBFl7cribfVbCsiMJUbXyAE=
 github.com/usbarmory/virtio-net v0.0.0-20250404103528-b6d7d034de85 h1:0K5rn95WsQks0etZfVgXjZhhvlMKlWqEhD4lPC1aLMM=
 github.com/usbarmory/virtio-net v0.0.0-20250404103528-b6d7d034de85/go.mod h1:Ox6pqVZbYx8slRdVru3c7VmUkMPjWe0IhIpjWQX9DXU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=

--- a/network/cloud_hypervisor.go
+++ b/network/cloud_hypervisor.go
@@ -51,7 +51,7 @@ func Init(console *shell.Interface, hasUSB bool, hasEth bool, nic **vnet.Net) {
 	dev.Start(false)
 
 	transport.EnableInterrupt(VIRTIO_NET0_IRQ, vm.AMD64.LAPIC, vnet.ReceiveQueue)
-	startInterruptHandler(dev, vm.AMD64.LAPIC, nil)
+	startInterruptHandler(dev, vm.AMD64, nil)
 
 	return
 }

--- a/network/firecracker.go
+++ b/network/firecracker.go
@@ -39,7 +39,7 @@ func Init(console *shell.Interface, hasUSB bool, hasEth bool, nic **vnet.Net) {
 	// used with `dev.Start(true)`.
 	dev.Start(false)
 
-	startInterruptHandler(dev, microvm.AMD64.LAPIC, microvm.IOAPIC0)
+	startInterruptHandler(dev, microvm.AMD64, microvm.IOAPIC0)
 
 	return
 }

--- a/network/microvm.go
+++ b/network/microvm.go
@@ -40,7 +40,7 @@ func Init(console *shell.Interface, hasUSB bool, hasEth bool, nic **vnet.Net) {
 	// used with `dev.Start(true)`.
 	dev.Start(false)
 
-	startInterruptHandler(dev, microvm.AMD64.LAPIC, microvm.IOAPIC1)
+	startInterruptHandler(dev, microvm.AMD64, microvm.IOAPIC1)
 
 	return
 }


### PR DESCRIPTION
This PR follows [tamago1.24.6 release](https://github.com/usbarmory/tamago-go/releases/tag/tamago-go1.24.6) and add SMP support for microvm targets.