### PR TITLE
Add boot disk support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ QEMU ?= qemu-system-x86_64 -machine microvm,x-option-roms=on,pit=off,pic=off,rtc
         -device virtio-net-device,netdev=net0 -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
 
 # emulate cloud VM (ops onprem)
-QEMU-img ?= qemu-system-x86_64 -machine q35 -m 4G -s \
+QEMU-img ?= qemu-system-x86_64 -machine q35 -m 4G \
             -machine accel=kvm:tcg -cpu max \
             -vga none -display none -serial stdio \
             -device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=pcie.0,multifunction=on,addr=0x3 \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,22 @@ QEMU ?= qemu-system-x86_64 -machine microvm,x-option-roms=on,pit=off,pic=off,rtc
         -enable-kvm -cpu host,invtsc=on,kvmclock=on -no-reboot \
         -m 4G -nographic -monitor none -serial stdio \
         -device virtio-net-device,netdev=net0 -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
+
+# emulate cloud VM (ops onprem)
+QEMU-img ?= qemu-system-x86_64 -machine q35 -m 4G -s \
+            -machine accel=kvm:tcg -cpu max \
+            -vga none -display none -serial stdio \
+            -device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=pcie.0,multifunction=on,addr=0x3 \
+            -device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=pcie.0,addr=0x3.0x1 \
+            -device pcie-root-port,port=0x12,chassis=3,id=pci.3,bus=pcie.0,addr=0x3.0x2 \
+            -device virtio-scsi-pci,bus=pci.2,addr=0x0,id=scsi0 \
+            -device scsi-hd,bus=scsi0.0,drive=hd0 \
+            -device isa-debug-exit \
+            -device virtio-rng-pci \
+            -device virtio-balloon \
+            -device virtio-net,bus=pci.3,addr=0x0,netdev=n0,mac=9e:f0:e8:26:9a:1b \
+            -drive file=$(APP).img,format=raw,if=none,id=hd0 \
+            -netdev user,id=n0
 endif
 
 ifeq ($(TARGET),$(filter $(TARGET), firecracker cloud_hypervisor))
@@ -68,7 +84,8 @@ check_tamago:
 	fi
 
 clean:
-	@rm -fr $(APP) $(APP).bin $(APP).imx $(APP)-signed.imx $(APP).csf $(APP).dcd cmd/IMX6UL*.yaml qemu.dtb tools/bios.bin
+	@rm -fr $(APP) $(APP).bin $(APP).img $(APP).imx $(APP)-signed.imx $(APP).csf $(APP).dcd
+	@rm -fr cmd/IMX6UL*.yaml qemu.dtb tools/bios.bin tools/mbr.bin tools/mbr.lst
 
 #### generic targets ####
 
@@ -90,8 +107,52 @@ qemu-gdb: GOFLAGS := $(GOFLAGS:-s=)
 qemu-gdb: $(APP)
 	$(QEMU) -kernel $(APP) -S -s
 
+qemu-img: $(APP).img
+	$(QEMU-img)
+
+qemu-img-gdb: $(APP).img
+	$(QEMU-img) -S -s
+
+#### AMD64 targets ####
+
+ifeq ($(TARGET),microvm)
+img: $(APP).img
+
+$(APP).bin: $(APP)
+	objcopy -j .text -j .rodata -j .shstrtab -j .typelink \
+	    -j .itablink -j .gopclntab -j .go.buildinfo -j .noptrdata -j .data \
+	    -j .bss --set-section-flags .bss=alloc,load,contents \
+	    -j .noptrbss --set-section-flags .noptrbss=alloc,load,contents \
+	    $(APP) -O binary $(APP).bin
+
+tools/mbr.bin: tools/mbr.s $(APP) $(APP).bin
+	OFFSET=200 && \
+	  SIZE=$$(stat -c %s $(APP).bin) && \
+	  ENTRY=0x$$(dd if=$(APP) bs=1 count=4 skip=24 | xxd -e -g4 | xxd -r | xxd -p) && \
+	  START=$(TEXT_START) && \
+	  echo "TAMAGO_OFFSET = $$OFFSET" && \
+	  echo "TAMAGO_SIZE = $$SIZE" && \
+	  echo "TAMAGO_ENTRY = $$ENTRY" && \
+	  echo "TAMAGO_START = $$START" && \
+	  nasm -l tools/mbr.lst tools/mbr.s -o $@ \
+	    -dTAMAGO_OFFSET=$$OFFSET \
+	    -dTAMAGO_SIZE=$$SIZE \
+	    -dTAMAGO_START=$$START \
+	    -dTAMAGO_ENTRY=$$ENTRY
+	@if (( $$(stat -c %s tools/mbr.bin) != 512 )); then \
+		echo "ERROR: tools/mbr.bin size != 512."; \
+		exit 1; \
+	fi
+
+$(APP).img: $(APP).bin tools/mbr.bin
+	dd if=/dev/zero of=$(APP).img bs=1M count=100 status=none
+	dd if=tools/mbr.bin of=$(APP).img conv=notrunc status=none
+	dd if=$(APP).bin of=$(APP).img bs=1024 seek=100 conv=notrunc status=none
+endif
+
 #### ARM targets ####
 
+ifeq ($(TARGET),$(filter $(TARGET), mx6ullevk usbarmory))
 imx: $(APP).imx
 
 imx_signed: $(APP)-signed.imx
@@ -142,6 +203,7 @@ $(APP).dcd:
 		echo "invalid target - options are: usbarmory, mx6ullevk"; \
 		exit 1; \
 	fi
+endif
 
 #### RISC-V targets ####
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,39 @@ make example TARGET=firecracker
 firectl --kernel example --root-drive /dev/null --tap-device tap0/06:00:AC:10:00:01 -c 4 -m 4096
 ```
 
+Google Compute Engine
+---------------------
+
+The following example uses Google Cloud CLI.
+
+Upload the raw image in a bucket and create an instance:
+
+```
+make example TARGET=microvm img
+cp example.img disk.raw
+tar --format=oldgnu -Sczf compressed-image.tar.gz disk.raw
+gcloud storage buckets create gs://tamago-bucket
+gcloud storage cp compressed-image.tar.gz gs://tamago-bucket
+gcloud compute images create tamago-example --source-uri gs://tamago-bucket/compressed-image.tar.gz --architecture=X86_64
+gcloud compute instances create tamago-example --zone=europe-west1-b --machine-type=n1-standard-2 --metadata="serial-port-enable=true" --image tamago-example
+```
+
+Check the serial port output:
+
+```
+gcloud compute instances get-serial-port-output tamago-example --zone=europe-west1-b --port=1
+```
+
+Clean up:
+
+```
+gcloud storage rm gs://tamago-bucket/compressed-image.tar.gz
+gcloud storage buckets delete gs://tamago-bucket
+gcloud compute instances stop tamago-example --zone europe-west1-b
+gcloud compute instances delete tamago-example --zone europe-west1-b
+gcloud compute images delete tamago-example
+```
+
 Building and executing on ARM targets
 =====================================
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/usbarmory/crucible v0.0.0-20250828082401-4bf849c8eba8
 	github.com/usbarmory/imx-enet v0.0.0-20250828084924-7bcc4d4a4518
 	github.com/usbarmory/imx-usbnet v0.0.0-20250828085206-21ec4d5ae4cd
-	github.com/usbarmory/tamago v0.0.0-20250909162020-d21f68e9a17f
+	github.com/usbarmory/tamago v1.25.2-0.20251007123717-69948a1a1128
 	github.com/usbarmory/virtio-net v0.0.0-20250828102850-00cf9e4c20da
 	golang.org/x/crypto v0.42.0
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20250909191931-8c9ba3183610

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/usbarmory/imx-enet v0.0.0-20250828084924-7bcc4d4a4518 h1:AyH/LDHBZFBq
 github.com/usbarmory/imx-enet v0.0.0-20250828084924-7bcc4d4a4518/go.mod h1:xv0Cs172SG66RZYFUX7XuZCuvHpiyE9Jgbz08Pwobqk=
 github.com/usbarmory/imx-usbnet v0.0.0-20250828085206-21ec4d5ae4cd h1:5Zfv1E6tpWblrtIXeUeavATxBMpHV6Bjn5w7EwQJ5cQ=
 github.com/usbarmory/imx-usbnet v0.0.0-20250828085206-21ec4d5ae4cd/go.mod h1:zvzUu4SfzoCEDVnxzga81SoK3ezsW8gjxck2v1Ry1zw=
-github.com/usbarmory/tamago v0.0.0-20250909162020-d21f68e9a17f h1:joymhH/y6IgeIkLXcBSGB9rHRdP5yTsbIGe2hr9z2So=
-github.com/usbarmory/tamago v0.0.0-20250909162020-d21f68e9a17f/go.mod h1:F10GriCplrO5/E/B4HFdtIN1nZ3LsjDdwM/GBiH8o+o=
+github.com/usbarmory/tamago v1.25.2-0.20251007123717-69948a1a1128 h1:KvIOeKCQ0m4ft5p39kOLv17rnoY8zMNq+7f9A5Rc2ro=
+github.com/usbarmory/tamago v1.25.2-0.20251007123717-69948a1a1128/go.mod h1:EXc/MNBHWuwlYGi2N3VRfR9oYfGYnOkqasoxP4SM4Ig=
 github.com/usbarmory/virtio-net v0.0.0-20250828102850-00cf9e4c20da h1:3jvGVOZB7DF9HNdiXZRzMwm//z935AOb9Oge+emUaJg=
 github.com/usbarmory/virtio-net v0.0.0-20250828102850-00cf9e4c20da/go.mod h1:Ox6pqVZbYx8slRdVru3c7VmUkMPjWe0IhIpjWQX9DXU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,5 @@
 This directory contains the following helpers:
 
   * to launch `tamago/riscv64` binaries under qemu: bios.
-  * to launch `tamago/amd64` binaries as disk images under qemu: mbr.
+  * to launch `tamago/amd64` binaries as disk images under qemu and supported
+    cloud KVMs: mbr.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,4 @@
 This directory contains the following helpers:
 
-  * to launch `tamago/riscv64`  binaries under qemu: bios.
+  * to launch `tamago/riscv64` binaries under qemu: bios.
+  * to launch `tamago/amd64` binaries as disk images under qemu: mbr.

--- a/tools/build_mbr.sh
+++ b/tools/build_mbr.sh
@@ -1,0 +1,18 @@
+ELF=$1
+BIN=$2
+START=$3
+
+OFFSET=200
+SIZE=$(stat -c %s $BIN)
+ENTRY=0x$(dd if=$ELF bs=1 count=4 skip=24 | xxd -e -g4 | xxd -r | xxd -p)
+
+echo "TAMAGO_OFFSET = $OFFSET"
+echo "TAMAGO_SIZE   = $SIZE"
+echo "TAMAGO_ENTRY  = $ENTRY"
+echo "TAMAGO_START  = $START"
+
+nasm -l mbr.lst mbr.s -o mbr.bin \
+    -dTAMAGO_OFFSET=$OFFSET \
+    -dTAMAGO_SIZE=$SIZE \
+    -dTAMAGO_START=$START \
+    -dTAMAGO_ENTRY=$ENTRY

--- a/tools/mbr.s
+++ b/tools/mbr.s
@@ -1,0 +1,134 @@
+base equ 0x7c00
+buffer equ 0x10000 ; 0x10000 - 0x1ffff: 64kB readsectors buffer
+
+%macro ENTER_REAL 0
+	bits 32
+	mov [stack.prot], esp
+	jmp gdt32.code16:%%prot16
+
+%%prot16:
+	bits 16
+	mov eax, cr0
+	and eax, ~1
+	mov cr0, eax
+	jmp 0:%%real
+
+%%real:
+	xor ax, ax
+	mov ds, ax
+	mov ss, ax
+	mov sp, [stack.real]
+%endmacro
+
+%macro ENTER_PROTECTED 0
+	bits 16
+	mov eax, cr0
+	or eax, 1
+	mov cr0, eax
+	jmp gdt32.code32:%%protected
+
+%%protected:
+	bits 32
+	mov eax, gdt32.data32
+	mov ds, eax
+	mov ss, eax
+	mov esp, [stack.prot]
+%endmacro
+
+init:
+	bits 16
+	org base
+
+	xor ax, ax
+	mov ds, ax
+	mov ss, ax
+
+	cli
+	mov eax, base
+	mov [stack.real], ax
+	sub eax, 0x100
+	mov [stack.prot], eax
+
+	lgdt [gdt32.desc]
+	ENTER_PROTECTED
+
+read_tamago:
+	bits 32
+	ENTER_REAL
+	call readsectors
+	ENTER_PROTECTED
+	call memcpy32
+	;increment lba
+	mov eax, [dap.lba]
+	add eax, 64
+	mov [dap.lba], eax
+	mov eax, [tamago.sector_size]
+	sub eax, 64
+	mov [tamago.sector_size], eax
+	cmp eax, 0
+	jg read_tamago
+	jmp [tamago.entry]
+
+; 32-bit GDT
+	align 4
+gdt32:
+	dw 0,0,0,0
+.code32 equ $ - gdt32
+	dw 0xffff,0,0x9a00,0xcf
+.data32 equ $ - gdt32
+	dw 0xffff,0,0x9200,0xcf
+.code16 equ $ - gdt32
+	dw 0xffff,0,0x9a00,0x00
+.data16 equ $ - gdt32
+	dw 0xffff,0,0x9200,0x00
+.desc:
+	dw $ - gdt32 -1
+	dd gdt32
+
+; real and protected stack pointer saving location
+stack:
+	.real	dw 0
+	.prot	dd 0
+
+; disk address packet structure
+dap:
+	db 0x10
+	db 0
+	.sector_count	dw 64			; 32 kB = 0x8000
+	.offset		dw 0
+	.segment	dw (buffer >> 4)	; readsector buffer: 0x10000-0x1ffff
+	.lba		dq 200
+
+; TAMAGO_* parameters should be provided externally
+tamago:
+	.offset		dq TAMAGO_OFFSET		;tamago image start sector
+	.sector_size	dq TAMAGO_SIZE/512		;tamago size in sectors
+	.start		dq TAMAGO_START			;tamago binary destination address
+	.entry		dq TAMAGO_ENTRY			;tamago entry point
+
+readsectors:
+	bits 16:
+	mov si, dap
+	mov ah, 0x42
+	mov dl, 0x80
+	int 0x13
+	ret
+
+memcpy32:
+	bits 32:
+	mov ebx, 0
+	mov ecx, [tamago.start]
+	mov edx, buffer
+copy:	mov eax, [edx]
+	mov [ecx], eax
+	add ecx, 4
+	add edx, 4
+	add ebx, 4
+	cmp ebx, 0x8000		; copy 32kB chunks
+	jne copy
+	mov [tamago.start], ecx	; save pointer for next chunk
+	ret
+
+times (446-$+$$) db 0	; ensure output binary is 512 bytes
+times 64 db 0		; parition table
+dw 0xAA55		; mbr signature

--- a/tools/mbr.s
+++ b/tools/mbr.s
@@ -43,6 +43,11 @@ init:
 	mov ds, ax
 	mov ss, ax
 
+	; disable 8259 PIC
+	mov al, 0xff
+	out 0xa1, al
+	out 0x21, al
+
 	cli
 	mov eax, base
 	mov [stack.real], ax


### PR DESCRIPTION
This patch allows to build a raw disk image that can be booted directly by VM's BIOS.

The produced example.img can be used to create cloud VMs instances that support legacy BIOS boot such as Google Cloud Engine and Amazon EC2.