### PR TITLE
add TARGET=gcp for Google Compute Engine BSP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ QEMU ?= qemu-system-x86_64 -machine q35,pit=off,pic=off \
         -enable-kvm -cpu host,invtsc=on,kvmclock=on -no-reboot \
         -m 4G -nographic -monitor none -serial stdio \
         -device pcie-root-port,port=0x10,chassis=1,id=pci.0,bus=pcie.0,multifunction=on,addr=0x3 \
-        -device virtio-net-pci,netdev=net0,mac=9e:f0:e8:26:9a:1b,disable-modern=true -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
+        -device virtio-net-pci,netdev=net0,mac=42:01:0a:84:00:02,disable-modern=true -netdev tap,id=net0,ifname=tap0,script=no,downscript=no
 
 QEMU-img ?= qemu-system-x86_64 -machine q35 -m 4G -smp $(SMP) \
             -machine accel=kvm:tcg -cpu max \
@@ -47,7 +47,7 @@ QEMU-img ?= qemu-system-x86_64 -machine q35 -m 4G -smp $(SMP) \
             -device isa-debug-exit \
             -device virtio-rng-pci \
             -device virtio-balloon \
-            -device virtio-net-pci=netdev=net0,mac=9e:f0:e8:26:9a:1b,disable-modern=true -netdev tap,id=net0,ifname=tap0,script=no,downscript=no \
+            -device virtio-net-pci=netdev=net0,mac=42:01:0a:84:00:02,disable-modern=true -netdev tap,id=net0,ifname=tap0,script=no,downscript=no \
             -drive file=$(APP).img,format=raw,if=none,id=hd0
 
 endif

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Building and executing on AMD64 targets
 | `cloud_hypervisor` | [Cloud Hypervisor](https://www.cloudhypervisor.org/)                      | [cloud_hypervisor/vm](https://github.com/usbarmory/tamago/tree/master/board/cloud_hypervisor/vm#executing-and-debugging) | VirtIO networking¹ |
 | `firecracker`      | [Firecracker microvm](https://firecracker-microvm.github.io/)             | [firecracker/microvm](https://github.com/usbarmory/tamago/tree/master/board/firecracker/microvm#executing-and-debugging) | VirtIO networking¹ |
 | `microvm`          | [QEMU microvm](https://www.qemu.org/docs/master/system/i386/microvm.html) | [qemu/microvm](https://github.com/usbarmory/tamago/tree/master/board/qemu/microvm#executing-and-debugging)               | VirtIO networking¹ |
-| `gcp`              | [Google Compute Engine](https://cloud.google.com/products/compute)        | [tools](https://github.com/usbarmory/tamago-example/tree/master/tools)                                                   | VirtIO networking  |
+| `gcp`              | [Google Compute Engine](https://cloud.google.com/products/compute)        | [tools](https://github.com/usbarmory/tamago-example/tree/master/tools)                                                   | VirtIO networking¹ |
 
 ¹ network configuration example in  _Emulated hardware with QEMU_
 
@@ -180,6 +180,9 @@ Google Compute Engine
 
 The `gcp` target can be executed on [Google Compute Engine](https://cloud.google.com/products/compute), see
 [tools](https://github.com/usbarmory/tamago-example/tree/master/tools) for more information.
+
+It can also be executed in _Emulated hardware with QEMU_ but with IP address
+10.132.0.1/24, instead of 10.0.0.2/24.
 
 Building and executing on ARM targets
 =====================================
@@ -246,6 +249,9 @@ ip tuntap add dev tap0 mode tap group <your user group>
 ip addr add 10.0.0.2/24 dev tap0
 ip link set tap0 up
 ```
+
+> [!NOTE] > `TARGET=gcp` requires 10.132.0.1/24 as IP address, instead of
+> 10.0.0.2/24
 
 An emulated target can be debugged with GDB using `make qemu-gdb`, this will
 make qemu waiting for a GDB connection that can be launched as follows:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ execute bare metal Go code on the following platforms:
 | AMD/Intel 64-bit      | [Cloud Hypervisor](https://www.cloudhypervisor.org)                                                                                                                                  | [amd64](https://github.com/usbarmory/tamago/tree/master/amd64)            | [cloud_hypervisor/vm](https://github.com/usbarmory/tamago/tree/master/board/cloud_hypervisor/vm) |
 | AMD/Intel 64-bit      | [QEMU microvm](https://www.qemu.org/docs/master/system/i386/microvm.html)                                                                                                            | [amd64](https://github.com/usbarmory/tamago/tree/master/amd64)            | [qemu/microvm](https://github.com/usbarmory/tamago/tree/master/board/qemu/microvm)               |
 | AMD/Intel 64-bit      | [Firecracker microvm](https://firecracker-microvm.github.io)                                                                                                                         | [amd64](https://github.com/usbarmory/tamago/tree/master/amd64)            | [firecracker/microvm](https://github.com/usbarmory/tamago/tree/master/board/firecracker/microvm) |
+| AMD/Intel 64-bit      | [Google Compute Engine](https://cloud.google.com/products/compute)                                                                                                                   | [amd64](https://github.com/usbarmory/tamago/tree/master/amd64)            | [google/gcp](https://github.com/usbarmory/tamago/tree/master/board/google/gcp)                   |
 | NXP i.MX6ULZ/i.MX6UL  | [USB armory Mk II](https://github.com/usbarmory/usbarmory/wiki/Mk-II-Introduction)                                                                                                   | [imx6ul](https://github.com/usbarmory/tamago/tree/master/soc/nxp/imx6ul)  | [usbarmory/mk2](https://github.com/usbarmory/tamago/tree/master/board/usbarmory)                 |
 | NXP i.MX6ULL/i.MX6UL  | [USB armory Mk II LAN](https://github.com/usbarmory/usbarmory/wiki/Mk-II-LAN)                                                                                                        | [imx6ul](https://github.com/usbarmory/tamago/tree/master/soc/nxp/imx6ul)  | [usbarmory/mk2](https://github.com/usbarmory/tamago/tree/master/board/usbarmory)                 |
 | NXP i.MX6ULL/i.MX6ULZ | [MCIMX6ULL-EVK](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/evaluation-kit-for-the-i-mx-6ull-and-6ulz-applications-processor:MCIMX6ULL-EVK) | [imx6ul](https://github.com/usbarmory/tamago/tree/master/soc/nxp/imx6ul)  | [nxp/mx6ullevk](https://github.com/usbarmory/tamago/tree/master/board/nxp/mx6ullevk)             |
@@ -142,7 +143,7 @@ Building and executing on AMD64 targets
 | `cloud_hypervisor` | [Cloud Hypervisor](https://www.cloudhypervisor.org/)                      | [cloud_hypervisor/vm](https://github.com/usbarmory/tamago/tree/master/board/cloud_hypervisor/vm#executing-and-debugging) | VirtIO networking¹ |
 | `firecracker`      | [Firecracker microvm](https://firecracker-microvm.github.io/)             | [firecracker/microvm](https://github.com/usbarmory/tamago/tree/master/board/firecracker/microvm#executing-and-debugging) | VirtIO networking¹ |
 | `microvm`          | [QEMU microvm](https://www.qemu.org/docs/master/system/i386/microvm.html) | [qemu/microvm](https://github.com/usbarmory/tamago/tree/master/board/qemu/microvm#executing-and-debugging)               | VirtIO networking¹ |
-| `microvm`          | [Google Compute Engine](https://cloud.google.com/products/compute)        | [tools](https://github.com/usbarmory/tamago-example/tree/master/tools)                                                   | WiP (serial only)  |
+| `gcp`              | [Google Compute Engine](https://cloud.google.com/products/compute)        | [tools](https://github.com/usbarmory/tamago-example/tree/master/tools)                                                   | VirtIO networking  |
 
 ¹ network configuration example in  _Emulated hardware with QEMU_
 
@@ -177,7 +178,7 @@ make qemu TARGET=microvm SMP=4
 Google Compute Engine
 ---------------------
 
-The `microvm` target can be executed on [Google Compute Engine](https://cloud.google.com/products/compute), see
+The `gcp` target can be executed on [Google Compute Engine](https://cloud.google.com/products/compute), see
 [tools](https://github.com/usbarmory/tamago-example/tree/master/tools) for more information.
 
 Building and executing on ARM targets

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Cloud Hypervisor
 
 ```
 make example TARGET=cloud_hypervisor
-cloud-hypervisor --kernel example --cpus boot=1 --memory size=4096M --net "tap=tap0" --serial tty --console off --seccomp false
+cloud-hypervisor --kernel example --cpus boot=4 --memory size=4096M --net "tap=tap0" --serial tty --console off --seccomp false
 ```
 
 Firecracker

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || microvm || firecracker
+//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || firecracker || microvm || gcp
 
 package cmd
 

--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -1,0 +1,38 @@
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build gcp
+
+package cmd
+
+import (
+	"github.com/usbarmory/tamago/board/google/gcp"
+	"github.com/usbarmory/tamago/kvm/clock"
+)
+
+const boardName = "gcp"
+
+func init() {
+	Terminal = gcp.UART0
+
+	// set date and time at boot
+	gcp.AMD64.SetTime(kvmclock.Now().UnixNano())
+}
+
+func date(epoch int64) {
+	gcp.AMD64.SetTime(epoch)
+}
+
+func uptime() (ns int64) {
+	return gcp.AMD64.GetTime() - gcp.AMD64.TimerOffset
+}
+
+func Target() (name string, freq uint32) {
+	return gcp.AMD64.Name(), gcp.AMD64.Freq()
+}
+
+func HasNetwork() (usb bool, eth bool) {
+	return false, true
+}

--- a/cmd/ntp.go
+++ b/cmd/ntp.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || microvm || firecracker
+//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || firecracker || microvm || gcp
 
 package cmd
 

--- a/cmd/wormhole.go
+++ b/cmd/wormhole.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || microvm || firecracker
+//go:build imx8mpevk || mx6ullevk || usbarmory || cloud_hypervisor || firecracker || microvm || gcp
 
 package cmd
 

--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,6 @@ require (
 	nhooyr.io/websocket v1.8.17 // indirect
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1 // indirect
 )
+
+replace github.com/usbarmory/tamago => /mnt/git/public/tamago
+replace github.com/usbarmory/virtio-net => /mnt/git/public/virtio-net

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,3 @@ require (
 	nhooyr.io/websocket v1.8.17 // indirect
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1 // indirect
 )
-
-replace github.com/usbarmory/tamago => /mnt/git/public/tamago
-replace github.com/usbarmory/virtio-net => /mnt/git/public/virtio-net

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main() {
 	banner := fmt.Sprintf("%s/%s (%s) • %s",
 		runtime.GOOS, runtime.GOARCH, runtime.Version(), name)
 
+	log.Printf(banner)
+
 	console := &shell.Interface{
 		Banner: banner,
 		Log:    logFile,

--- a/network/const.go
+++ b/network/const.go
@@ -19,7 +19,7 @@ import (
 // For more advanced use cases gVisor supports sharing a single stack across
 // different NIC IDs and routing while this example simply clones interface
 // configuration and stack.
-const (
+var (
 	MAC      = "1a:55:89:a2:69:41"
 	Netmask  = "255.255.255.0"
 	IP       = "10.0.0.1"

--- a/network/gcp.go
+++ b/network/gcp.go
@@ -1,0 +1,55 @@
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build gcp
+
+package network
+
+import (
+	"log"
+
+	"github.com/usbarmory/tamago-example/shell"
+	"github.com/usbarmory/tamago/board/google/gcp"
+	"github.com/usbarmory/tamago/kvm/virtio"
+	"github.com/usbarmory/tamago/soc/intel/pci"
+	"github.com/usbarmory/virtio-net"
+)
+
+// chosen by the application for MSI-X signaling
+const VIRTIO_NET0_IRQ = 32
+
+func Init(console *shell.Interface, hasUSB bool, hasEth bool, nic **vnet.Net) {
+	if hasUSB {
+		log.Fatalf("unsupported")
+	}
+
+	transport := &virtio.LegacyPCI{
+		Device: pci.Probe(
+			0,
+			gcp.VIRTIO_NET_PCI_VENDOR,
+			gcp.VIRTIO_NET_PCI_DEVICE,
+		),
+	}
+
+	dev := &vnet.Net{
+		Transport:    transport,
+		IRQ:          VIRTIO_NET0_IRQ,
+		HeaderLength: 10,
+	}
+
+	*nic = dev
+
+	if err := startNet(console, dev); err != nil {
+		log.Printf("could not start networking, %v", err)
+		return
+	}
+
+	// This example illustrates IRQ handling, alternatively a poller can be
+	// used with `dev.Start(true)`.
+	dev.Start(false)
+
+	transport.EnableInterrupt(VIRTIO_NET0_IRQ, vnet.ReceiveQueue)
+	startInterruptHandler(dev, gcp.AMD64, gcp.IOAPIC0)
+}

--- a/network/gcp.go
+++ b/network/gcp.go
@@ -39,6 +39,10 @@ func Init(console *shell.Interface, hasUSB bool, hasEth bool, nic **vnet.Net) {
 		HeaderLength: 10,
 	}
 
+	MAC      = "42:01:0a:84:00:02"
+	IP       = "10.132.0.2"
+	Gateway  = "10.132.0.1"
+
 	*nic = dev
 
 	if err := startNet(console, dev); err != nil {

--- a/network/stub.go
+++ b/network/stub.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-//go:build !(cloud_hypervisor || firecracker || microvm || imx8mpevk || mx6ullevk || usbarmory)
+//go:build !(cloud_hypervisor || firecracker || microvm || gcp || imx8mpevk || mx6ullevk || usbarmory)
 
 package network
 

--- a/network/virtio.go
+++ b/network/virtio.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-//go:build cloud_hypervisor || firecracker || microvm
+//go:build cloud_hypervisor || firecracker || microvm || gcp
 
 package network
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,7 +18,7 @@ Upload the raw image in a bucket and create an instance:
 
 ```
 cd tamago-example
-make example TARGET=microvm img
+make example TARGET=gcp img
 cp example.img disk.raw
 tar --format=oldgnu -Sczf compressed-image.tar.gz disk.raw
 gcloud storage buckets create gs://tamago-bucket

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,30 +14,39 @@ The following example adapts a tamago/amd64 unikernel for execution on Google
 Compute Engine, deploying with Google Cloud CLI (though tools like
 [ops](https://github.com/nanovms/ops) can also be used).
 
+First of all a unique bucket name should be picked:
+
+```
+export BUCKET=tamago-example-$(date +%s)-bucket
+```
+
 Upload the raw image in a bucket and create an instance:
 
 ```
-cd tamago-example
 make example TARGET=gcp img
 cp example.img disk.raw
 tar --format=oldgnu -Sczf compressed-image.tar.gz disk.raw
-gcloud storage buckets create gs://tamago-bucket
-gcloud storage cp compressed-image.tar.gz gs://tamago-bucket
-gcloud compute images create tamago-example --source-uri gs://tamago-bucket/compressed-image.tar.gz --architecture=X86_64
-gcloud compute instances create tamago-example --zone=europe-west1-b --machine-type=n1-standard-2 --metadata="serial-port-enable=true" --image tamago-example
+gcloud storage buckets create gs://$BUCKET
+gcloud storage cp compressed-image.tar.gz gs://$BUCKET
+gcloud compute images create tamago-example --source-uri gs://$BUCKET/compressed-image.tar.gz --architecture=X86_64
+gcloud compute instances create tamago-example --zone=europe-west1-b --machine-type=t2d-standard-1 --metadata="serial-port-enable=1" --image tamago-example --private-network-ip 10.132.0.2
 ```
 
-Check the serial port output:
+Connect to serial port:
 
 ```
+# output: unikernels with serial output only, no console input
 gcloud compute instances get-serial-port-output tamago-example --zone=europe-west1-b --port=1
+
+# input/output: unikernels with interactive serial console
+gcloud compute connect-to-serial-port tamago-example --zone=europe-west1-b --port=1
 ```
 
-Clean up:
+Stop and delete instance:
 
 ```
-gcloud storage rm gs://tamago-bucket/compressed-image.tar.gz
-gcloud storage buckets delete gs://tamago-bucket
+gcloud storage rm gs://$BUCKET/compressed-image.tar.gz
+gcloud storage buckets delete gs://$BUCKET
 gcloud compute instances stop tamago-example --zone europe-west1-b
 gcloud compute instances delete tamago-example --zone europe-west1-b
 gcloud compute images delete tamago-example


### PR DESCRIPTION
This PR adds `TARGET=gcp` for execution under Google Compute Engine (machine type T2D).